### PR TITLE
Use logger in poll_until_state

### DIFF
--- a/py_builder_relayer_client/client.py
+++ b/py_builder_relayer_client/client.py
@@ -364,9 +364,11 @@ class RelayClient:
         if poll_frequency is not None and poll_frequency >= 1000:
             poll_frequency_ms = poll_frequency
 
-        print(
-            f"Waiting for transaction {transaction_id} matching states: {target_states}..."
-        )
+        self.logger.info(
+    "Waiting for transaction %s matching states: %s...",
+    transaction_id,
+    target_states,
+)
 
         for _ in range(poll_limit):
             transactions = self.get_transaction(transaction_id)


### PR DESCRIPTION
This PR replaces a direct `print()` call in `poll_until_state` with `self.logger.info()`.

Since this is a client library and the class already uses a logger for debug/error/info messages, routing the polling status message through the logger keeps output behavior consistent and lets consumers control verbosity through their logging configuration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to swapping a `print()` for `self.logger.info()` in transaction polling; behavior changes only in how the status message is emitted and can affect consumer log/console output.
> 
> **Overview**
> Routes the initial status message in `RelayClient.poll_until_state` through `self.logger.info()` instead of a direct `print()`, keeping polling output consistent with the library’s logging behavior and allowing consumers to control verbosity via logging configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f4860d9219344cd7fcfeda1d2286d312503897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->