### PR TITLE
fix(headers): use json.dumps for HMAC body serialization (closes #4)

### DIFF
--- a/py_builder_relayer_client/client.py
+++ b/py_builder_relayer_client/client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -415,7 +416,7 @@ class RelayClient:
         self, method: str, request_path: str, body: dict = None
     ) -> Optional[dict]:
         if body is not None:
-            body = str(body)
+            body = json.dumps(body)
         headers = self.builder_config.generate_builder_headers(
             method, request_path, body
         )

--- a/tests/test_client_headers.py
+++ b/tests/test_client_headers.py
@@ -1,0 +1,47 @@
+import json
+from unittest import TestCase
+from unittest.mock import Mock
+
+from py_builder_relayer_client.client import RelayClient
+
+
+# Public Hardhat/Anvil fixture key. This is not a live credential.
+TEST_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+class TestGenerateBuilderHeaders(TestCase):
+
+    def _client(self):
+        client = RelayClient(
+            relayer_url="http://localhost:8080",
+            chain_id=137,
+            private_key=TEST_PRIVATE_KEY,
+            builder_config=Mock(),
+        )
+        client.builder_config.generate_builder_headers = Mock(return_value=None)
+        return client
+
+    def test_body_is_serialized_as_valid_json(self):
+        """
+        The body handed to BuilderConfig.generate_builder_headers must be a
+        valid JSON string equal to json.dumps(body) — matching the bytes the
+        HTTP layer puts on the wire via `requests(..., json=body)`.
+        """
+        client = self._client()
+        body = {"from": "0xabc", "to": "0xdef", "nonce": "0"}
+
+        client._generate_builder_headers("POST", "/submit", body)
+
+        forwarded = client.builder_config.generate_builder_headers.call_args[0][2]
+        # Must round-trip as JSON
+        self.assertEqual(body, json.loads(forwarded))
+        # And must equal the exact wire-format string
+        self.assertEqual(json.dumps(body), forwarded)
+        # Specifically: not Python repr (single quotes)
+        self.assertNotIn("'", forwarded)
+
+    def test_none_body_is_passed_through(self):
+        client = self._client()
+        client._generate_builder_headers("GET", "/transaction", None)
+        forwarded = client.builder_config.generate_builder_headers.call_args[0][2]
+        self.assertIsNone(forwarded)


### PR DESCRIPTION
## Bug

`client.py:418` stringifies the request body with `str()` before HMAC:

​```python
if body is not None:
    body = str(body)
headers = self.builder_config.generate_builder_headers(method, request_path, body)
​```

`str({"a": "b"})` → `{'a': 'b'}` (Python repr, single quotes, not JSON).

## Why it breaks

The wire body is sent via `requests.request(..., json=body)` in
`http_helpers/helpers.py`, which serializes through `json.dumps(...)`
(double quotes). HMAC signs one string; the server verifies a different
one.

For `BuilderConfig.remote_builder_config`, the Node/Express
`builder-signing-server` fails `JSON.parse` on the Python repr and
returns 400 — this is what #4 reports.

## Fix

​```diff
-        body = str(body)
+        body = json.dumps(body)
​```

`json.dumps` with default separators matches `requests`' wire format
exactly, so the signed bytes and transmitted bytes are identical.

## Test

Adds `tests/test_client_headers.py` with two cases:
- the body handed to `BuilderConfig.generate_builder_headers` is valid
  JSON, equals `json.dumps(input_dict)`, and contains no single quotes
- a `None` body is passed through unchanged

Full suite: 22/22 passing.

## Compatibility

No public API change. `body` was already a `dict` at the call site
(`_post_request`); only the local rebinding inside
`_generate_builder_headers` changes.

Closes #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-signing header generation used for authenticated relayer calls; while the change is small, mismatched serialization could still break signature verification across clients/servers if expectations differ.
> 
> **Overview**
> Fixes builder header/HMAC signing to serialize request bodies with `json.dumps` (instead of Python `str(dict)`), aligning the signed bytes with the JSON payload sent via `requests(..., json=body)`.
> 
> Adds `tests/test_client_headers.py` to assert the forwarded body is valid JSON, matches `json.dumps(...)` exactly, and that `None` bodies are passed through unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2bbdd8363c106896743d5db429ad76bcd8bf8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->