### PR TITLE
fix: accept documented RelayClient constructor aliases

### DIFF
--- a/py_builder_relayer_client/client.py
+++ b/py_builder_relayer_client/client.py
@@ -72,19 +72,38 @@ class RelayClient:
 
     def __init__(
         self,
-        relayer_url,
-        chain_id: int,
+        relayer_url=None,
+        chain_id: int = None,
         private_key: str = None,
         builder_config: BuilderConfig = None,
         relay_tx_type=None,
         rpc_url: str = None,
+        *,
+        host: str = None,
+        chain: int = None,
+        signer: str = None,
+        relayer_api_key: str = None,
+        relayer_api_key_address: str = None,
     ):
+        if relayer_url is None:
+            relayer_url = host
+        if chain_id is None:
+            chain_id = chain
+        if private_key is None:
+            private_key = signer
+        if relayer_url is None:
+            raise TypeError("relayer_url is required")
+        if chain_id is None:
+            raise TypeError("chain_id is required")
+
         self.relayer_url = (
             relayer_url[0:-1] if relayer_url.endswith("/") else relayer_url
         )
         self.chain_id = chain_id
         self.contract_config = get_contract_config(chain_id)
         self.rpc_url = rpc_url
+        self.relayer_api_key = relayer_api_key
+        self.relayer_api_key_address = relayer_api_key_address
 
         self.signer = None
         if private_key is not None:

--- a/tests/test_client_deposit_wallet.py
+++ b/tests/test_client_deposit_wallet.py
@@ -36,6 +36,32 @@ class TestClientDepositWallet(TestCase):
         )
         return client
 
+    def test_constructor_accepts_documented_keyword_aliases(self):
+        client = RelayClient(
+            host="http://localhost:8080/",
+            chain=137,
+            signer=TEST_PRIVATE_KEY,
+            relayer_api_key="test-api-key",
+            relayer_api_key_address=ADDRESS,
+        )
+
+        self.assertEqual("http://localhost:8080", client.relayer_url)
+        self.assertEqual(137, client.chain_id)
+        self.assertEqual("test-api-key", client.relayer_api_key)
+        self.assertEqual(ADDRESS, client.relayer_api_key_address)
+        self.assertIsNotNone(client.signer)
+
+    def test_constructor_prefers_existing_parameter_names_over_aliases(self):
+        client = RelayClient(
+            relayer_url="http://localhost:8080",
+            host="http://example.com",
+            chain_id=137,
+            chain=80002,
+        )
+
+        self.assertEqual("http://localhost:8080", client.relayer_url)
+        self.assertEqual(137, client.chain_id)
+
     def test_get_expected_deposit_wallet(self):
         client = self._client()
         client._rpc_call = Mock(


### PR DESCRIPTION
## Summary
- accept the documented `host`, `chain`, and `signer` keyword aliases in `RelayClient.__init__`
- preserve the existing `relayer_url`, `chain_id`, and `private_key` API, with existing names taking precedence
- keep documented relayer API key fields on the client so the setup snippet no longer fails at construction

Fixes #25.

## Tests
- `uv run --with-requirements requirements.txt pytest tests/test_client_deposit_wallet.py -q`
- `uv run --with-requirements requirements.txt pytest -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constructor-only compatibility change with explicit validation; no changes to relay execution or auth header logic.
> 
> **Overview**
> **`RelayClient.__init__`** now accepts documented keyword aliases **`host`**, **`chain`**, and **`signer`** (keyword-only) as fallbacks when **`relayer_url`**, **`chain_id`**, and **`private_key`** are omitted. Existing parameter names still win when both are passed.
> 
> Construction **requires** a relayer URL and chain id after alias resolution; missing values raise **`TypeError`**. **`relayer_api_key`** and **`relayer_api_key_address`** are accepted and stored on the client instance.
> 
> Tests cover alias-based construction (including trailing-slash URL normalization) and precedence of canonical names over aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b27a09424e26baae6b4b4d1caa8871b9910e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->